### PR TITLE
tf_driver: Remove GROUP_INFO macro

### DIFF
--- a/security/tf_driver/tf_conn.c
+++ b/security/tf_driver/tf_conn.c
@@ -648,19 +648,21 @@ error:
  * requested GID */
 static bool tf_check_gid(gid_t requested_gid)
 {
-	if (requested_gid == current_egid()) {
-		return true;
-	} else {
+	bool retval = requested_gid == current_egid();
+	if (!retval) {
+		struct group_info *gi;
 		u32    size;
 		u32    i;
+
 		/* Look in the supplementary GIDs */
-		get_group_info(GROUP_INFO);
-		size = GROUP_INFO->ngroups;
-		for (i = 0; i < size; i++)
-			if (requested_gid == GROUP_AT(GROUP_INFO , i))
-				return true;
+		gi = get_group_info(get_current_groups());
+		size = gi->ngroups;
+		for (i = 0; !retval && i < size; i++)
+			if (requested_gid == GROUP_AT(gi, i))
+				retval = true;
+		put_group_info(gi);
 	}
-	return false;
+	return retval;
 }
 
 /*

--- a/security/tf_driver/tf_defs.h
+++ b/security/tf_driver/tf_defs.h
@@ -524,15 +524,4 @@ struct tf_device *tf_get_device(void);
 
 #define CLEAN_CACHE_CFG_MASK	(~0xC) /* 1111 0011 */
 
-/*----------------------------------------------------------------------------*/
-/*
- * Kernel Differences
- */
-
-#ifdef CONFIG_ANDROID
-#define GROUP_INFO		get_current_groups()
-#else
-#define GROUP_INFO		(current->group_info)
-#endif
-
 #endif  /* !defined(__TF_DEFS_H__) */


### PR DESCRIPTION
Looks like this was a relic from supporting an earlier kernel version.

This solves a compiler error when building without `CONFIG_ANDROID`.

Compiling without the Trusted Foundations driver is also possible, but doesn't seem to boot, and I believe would disable a lot of basic functionality anyway (like SMP).
